### PR TITLE
Add link to EveryMac serial lookup

### DIFF
--- a/Serial.xcodeproj/project.pbxproj
+++ b/Serial.xcodeproj/project.pbxproj
@@ -180,7 +180,10 @@
 				C3AE4E072333F45B0011BBDF /* Frameworks */,
 				C36F1A382256BA150007DC21 /* Products */,
 			);
+			indentWidth = 4;
 			sourceTree = "<group>";
+			tabWidth = 4;
+			usesTabs = 0;
 		};
 		C36F1A382256BA150007DC21 /* Products */ = {
 			isa = PBXGroup;

--- a/Serial/UI/ResultsViewController.swift
+++ b/Serial/UI/ResultsViewController.swift
@@ -52,7 +52,7 @@ class ResultsViewController: ThemedTableViewController {
             analysis.register { update($0.probableVersion) }
         })], header: "Operating System", footer: "The latest software version at the end of the week of manufacture. This may be inaccurate for newly released devices."))
         
-        sections.append(Section(rows: [ActionRow(title: "Open Tech Specs", url: analysis.techSpecsURL, viewController: self), ActionRow(title: "Check Coverage", url: analysis.checkCoverageURL, viewController: self)], header: "More Information", footer: nil))
+        sections.append(Section(rows: [ActionRow(title: "Open Tech Specs", url: analysis.techSpecsURL, viewController: self), ActionRow(title: "Check Coverage", url: analysis.checkCoverageURL, viewController: self), ActionRow(title: "EveryMac Lookup", url: analysis.everyMacURL, viewController: self)], header: "More Information", footer: nil))
         
         self.sections = sections
     }

--- a/SerialKit/SerialAnalysis.swift
+++ b/SerialKit/SerialAnalysis.swift
@@ -13,7 +13,7 @@ public class SerialAnalysis {
     public let serialNumber: String
     /// The last digits of the serial number which identify this device's model (Space Grey iPhone X, etc)
     public let modelPart: String
-    public let manufactureLocation: ManufactureLocation?, manufactureDate: ManufactureDate?, techSpecsURL: URL?, checkCoverageURL: URL?
+    public let manufactureLocation: ManufactureLocation?, manufactureDate: ManufactureDate?, techSpecsURL: URL?, checkCoverageURL: URL?, everyMacURL: URL?
     
     public init?(serialNumber: String) {
         self.serialNumber = serialNumber.uppercased()
@@ -26,6 +26,7 @@ public class SerialAnalysis {
         // Set Apple Support URLs
         techSpecsURL = URL(string: "https://support-sp.apple.com/sp/index?page=cpuspec&cc=\(modelPart)")
         checkCoverageURL = URL(string: "https://checkcoverage.apple.com/?sn=\(self.serialNumber)")
+        everyMacURL = URL(string: "https://everymac.com/ultimate-mac-lookup/?search_keywords=\(self.serialNumber)")
         fetchDeviceName()
     }
     


### PR DESCRIPTION
Was quick and easy to add so I figured why not, gives a good second opinion, straightforward url, clean site that doesn’t do any silly business. Haven’t tested Serial with earlier device serials yet but I know EveryMac do a good job of that. They don’t do estimated shipping iOS version though (that actually is valuable to know for some devices like iPhone 3GS). 